### PR TITLE
Initial 2.2.6 (retry)

### DIFF
--- a/LICENSE.build
+++ b/LICENSE.build
@@ -1,4 +1,5 @@
 Copyright (c) 2018 The Meson development team
+Copyright © 2018 Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 # Copyright © 2018 Dylan Baker
+# Copyright © 2018 Intel Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +23,8 @@ project(
   'expat',
   'c',
   license : 'MIT',
-  version : '2.2.5',
-  meson_version : '>= 0.44.0',
+  version : '2.2.6',
+  meson_version : '>= 0.48.0',
 )
 
 config = configuration_data()
@@ -32,11 +33,9 @@ cc = meson.get_compiler('c')
 # Define how much context to retain around the current parse point.
 config.set('XML_CONTEXT_BYTES', 1024)
 
-if get_option('use_libbsd')
-  dep_libbsd = dependency('libbsd')
+dep_libbsd = dependency('libbsd', required : get_option('use_libbsd'))
+if dep_libbsd.found()
   config.set('HAVE_LIBBSD', true)
-else
-  dep_libbsd = []
 endif
 
 if cc.has_function('arc4random_buf')
@@ -149,7 +148,7 @@ libexpat = library(
   vs_module_defs : 'lib/libexpat.def',
   include_directories : include_directories('lib'),
   dependencies : dep_libbsd,
-  version : '1.6.7',
+  version : '1.6.8',
   soversion : host_machine.system() != 'windows' ? '1' : '',
   install : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ foreach h : ['dlfcn', 'fcntl', 'inttypes', 'memory', 'stdint', 'stdlib',
   endif
 endforeach
 
-foreach f : ['getpagesize', 'bcopy', 'mmap', 'getrandom']
+foreach f : ['getpagesize', 'memmove', 'bcopy', 'mmap', 'getrandom']
   if cc.has_function(f)
     config.set('HAVE_@0@'.format(f.to_upper()), true)
   endif
@@ -115,24 +115,35 @@ if not ['windows', 'cygwin'].contains(host_machine.system())
   endif
 endif
 
-soversion = host_machine.system() != 'windows' ? '1' : ''
+_files = [
+  files(
+    'lib/loadlibrary.c', 'lib/xmlparse.c', 'lib/xmlrole.c', 'lib/xmltok.c',
+    'lib/xmltok_impl.c', 'lib/xmltok_ns.c',
+  ),
+  config_h,
+]
 
-libexpat = library(
-  'expat',
-  [
-    files(
-      'lib/loadlibrary.c', 'lib/xmlparse.c', 'lib/xmlrole.c', 'lib/xmltok.c',
-      'lib/xmltok_impl.c', 'lib/xmltok_ns.c',
-    ),
-    config_h,
-  ],
-  vs_module_defs : 'lib/libexpat.def',
-  include_directories : include_directories('lib'),
-  dependencies : dep_libbsd,
-  version : '1.6.7',
-  soversion : soversion,
-  install : get_option('default_library') == 'shared',
-)
+if cc.get_id() == 'msvc'
+  libexpat = library(
+    'expat',
+    _files,
+    vs_module_defs : 'lib/libexpat.def',
+    include_directories : include_directories('lib'),
+    dependencies : dep_libbsd,
+    version : '1.6.7',
+    install : get_option('default_library') == 'shared',
+  )
+else
+  libexpat = library(
+    'expat',
+    _files,
+    include_directories : include_directories('lib'),
+    dependencies : dep_libbsd,
+    version : '1.6.7',
+    soversion : host_machine.system() != 'windows' ? '1' : '',
+    install : get_option('default_library') == 'shared',
+  )
+endif
 
 expat_dep = declare_dependency(
   sources : config_h,

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ config = configuration_data()
 cc = meson.get_compiler('c')
 
 # Define how much context to retain around the current parse point.
-config.set('XML_CONTEXT_BYTES' 1024)
+config.set('XML_CONTEXT_BYTES', 1024)
 
 if get_option('use_libbsd')
   dep_libbsd = dependency('libbsd')
@@ -72,11 +72,11 @@ else
 endif
 
 
-if not (config.get('HAVE_SYS_TYPES_H', 0) == 1 and
+if not (config.get('HAVE_SYS_TYPES_H', false) and
         cc.has_header_symbol('sys/types.h', 'off_t'))
   config.set('off_t', 'long')
 endif
-if not (config.get('HAVE_SYS_TYPES_H', 0) == 1 and
+if not (config.get('HAVE_SYS_TYPES_H', false) and
         cc.has_header_symbol('sys/types.h', 'size_t'))
   config.set('size_t', 'unsigned')
 endif

--- a/meson.build
+++ b/meson.build
@@ -94,9 +94,29 @@ if cc.compiles('''
   config.set('HAVE_SYSCALL_GETRANDOM', true)
 endif
 
+# Install headers
 config_h = configure_file(
   configuration : config,
   output : 'expat_config.h',
+  install_dir : get_option('includedir'),
+  install : true,
+)
+install_headers('lib/expat.h', 'lib/expat_external.h')
+
+# pkg-config file
+pkgdata = configuration_data()
+pkgdata.set('prefix', get_option('prefix'))
+pkgdata.set('exec_prefix', get_option('prefix'))
+pkgdata.set('libdir', '${prefix}/' + get_option('libdir'))
+pkgdata.set('includedir', '${prefix}/' + get_option('includedir'))
+pkgdata.set('PACKAGE_VERSION', meson.project_version())
+
+configure_file(
+  input : 'expat.pc.in',
+  output : 'expat.pc',
+  configuration : pkgdata,
+  install_dir : join_paths(get_option('libdir'), 'pkgconfig'),
+  install: true
 )
 
 add_project_arguments('-DHAVE_EXPAT_CONFIG_H', language : ['c'])
@@ -123,27 +143,16 @@ _files = [
   config_h,
 ]
 
-if cc.get_id() == 'msvc'
-  libexpat = library(
-    'expat',
-    _files,
-    vs_module_defs : 'lib/libexpat.def',
-    include_directories : include_directories('lib'),
-    dependencies : dep_libbsd,
-    version : '1.6.7',
-    install : get_option('default_library') == 'shared',
-  )
-else
-  libexpat = library(
-    'expat',
-    _files,
-    include_directories : include_directories('lib'),
-    dependencies : dep_libbsd,
-    version : '1.6.7',
-    soversion : host_machine.system() != 'windows' ? '1' : '',
-    install : get_option('default_library') == 'shared',
-  )
-endif
+libexpat = library(
+  'expat',
+  _files,
+  vs_module_defs : 'lib/libexpat.def',
+  include_directories : include_directories('lib'),
+  dependencies : dep_libbsd,
+  version : '1.6.7',
+  soversion : host_machine.system() != 'windows' ? '1' : '',
+  install : true,
+)
 
 expat_dep = declare_dependency(
   sources : config_h,

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,145 @@
+# Copyright © 2018 Dylan Baker
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+project(
+  'expat',
+  'c',
+  license : 'MIT',
+  version : '2.2.5',
+  meson_version : '>= 0.44.0',
+)
+
+config = configuration_data()
+cc = meson.get_compiler('c')
+
+# Define how much context to retain around the current parse point.
+config.set('XML_CONTEXT_BYTES' 1024)
+
+if get_option('use_libbsd')
+  dep_libbsd = dependency('libbsd')
+  config.set('HAVE_LIBBSD', true)
+else
+  dep_libbsd = []
+endif
+
+if cc.has_function('arc4random_buf')
+  config.set('HAVE_ARC4RANDOM_BUF', true)
+elif cc.has_function('arc4random')
+  config.set('HAVE_ARC4RANDOM', true)
+endif
+
+if get_option('xml_dtd')
+  config.set('XML_DTD', true)
+endif
+if get_option('xml_ns')
+  config.set('XML_NS', true)
+endif
+
+foreach h : ['dlfcn', 'fcntl', 'inttypes', 'memory', 'stdint', 'stdlib',
+             'strings', 'string', 'sys/stat', 'sys/types', 'unistd']
+  if cc.has_header(h + '.h')
+    config.set('HAVE_@0@_H'.format(h.underscorify().to_upper()), true)
+  endif
+endforeach
+
+foreach f : ['getpagesize', 'bcopy', 'mmap', 'getrandom']
+  if cc.has_function(f)
+    config.set('HAVE_@0@'.format(f.to_upper()), true)
+  endif
+endforeach
+
+if host_machine.endian() == 'little'
+  config.set('BYTEORDER', 1234)
+else
+  config.set('BYTEORDER', 4321)
+endif
+
+
+if not (config.get('HAVE_SYS_TYPES_H', 0) == 1 and
+        cc.has_header_symbol('sys/types.h', 'off_t'))
+  config.set('off_t', 'long')
+endif
+if not (config.get('HAVE_SYS_TYPES_H', 0) == 1 and
+        cc.has_header_symbol('sys/types.h', 'size_t'))
+  config.set('size_t', 'unsigned')
+endif
+
+if cc.compiles('''
+      #include <stdlib.h>       /* for NULL */
+      #include <unistd.h>       /* for syscall */
+      #include <sys/syscall.h>  /* for SYS_getrandom */
+      int main() {
+        syscall(SYS_getrandom, NULL, 0, 0);
+        return 0;
+      }''',
+      name : 'SYS_getrandom',
+    )
+  config.set('HAVE_SYSCALL_GETRANDOM', true)
+endif
+
+config_h = configure_file(
+  configuration : config,
+  output : 'expat_config.h',
+)
+
+add_project_arguments('-DHAVE_EXPAT_CONFIG_H', language : ['c'])
+if cc.has_argument('-fno-strict-aliasing')
+  add_project_arguments('-fno-strict-aliasing', language : ['c'])
+endif
+if cc.get_id() == 'msvc'
+  add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', '-wd4996', language : ['c'])
+  if get_option('default_library') == 'static'
+    add_project_arguments('-DXML_STATIC', language : ['c'])
+  endif
+endif
+if not ['windows', 'cygwin'].contains(host_machine.system())
+  if get_option('use_dev_urandom')
+    add_project_arguments('-DXML_DEV_URANDOM', language : ['c'])
+  endif
+endif
+
+soversion = host_machine.system() != 'windows' ? '1' : ''
+
+libexpat = library(
+  'expat',
+  [
+    files(
+      'lib/loadlibrary.c', 'lib/xmlparse.c', 'lib/xmlrole.c', 'lib/xmltok.c',
+      'lib/xmltok_impl.c', 'lib/xmltok_ns.c',
+    ),
+    config_h,
+  ],
+  vs_module_defs : 'lib/libexpat.def',
+  include_directories : include_directories('lib'),
+  dependencies : dep_libbsd,
+  version : '1.6.7',
+  soversion : soversion,
+  install : get_option('default_library') == 'shared',
+)
+
+expat_dep = declare_dependency(
+  sources : config_h,
+  link_with : libexpat,
+  include_directories : include_directories('lib'),
+)
+
+# TODO: tools, examples, tests, docs
+# These are probably not necessary for a wrap, but someone might have use for
+# them

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,45 @@
+# Copyright © 2018 Dylan Baker
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(
+  'use_libbsd',
+  type : 'boolean',
+  value : false,
+  description : 'Use libbsd for arc4random_buf',
+)
+option(
+  'xml_dtd',
+  type : 'boolean',
+  value : true,
+  description : 'If true make parameter entity parsing functionality available',
+)
+option(
+  'xml_ns',
+  type : 'boolean',
+  value : true,
+  description : 'If true make XML Namespaces functionality available',
+)
+option(
+  'use_dev_urandom',
+  type : 'boolean',
+  value : true,
+  description : 'If true use /dev/urandom for entropy. Has no affect on platforms without /dev/urandom',
+)
+# TODO: tools, examples, tests, docs

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 # Copyright © 2018 Dylan Baker
+# Copyright © 2018 Intel Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +21,8 @@
 
 option(
   'use_libbsd',
-  type : 'boolean',
-  value : false,
+  type : 'feature',
+  value : 'auto',
   description : 'Use libbsd for arc4random_buf',
 )
 option(

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
-directory = expat-2.2.5
+directory = expat-2.2.6
 
-source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2
-source_filename = expat-2.2.5.tar.bz2
-source_hash = d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
+source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2
+source_filename = expat-2.2.6.tar.bz2
+source_hash = 17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = expat-2.2.5
+
+source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2
+source_filename = expat-2.2.5.tar.bz2
+source_hash = d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6


### PR DESCRIPTION
Carried over from https://github.com/mesonbuild/expat/pull/7 where I messed up all the branches by accident.

```
This is based on the 2.2.5 release, with the following changes:
 - Uses 2.2.6 source instead of 2.2.5
 - requires meson 0.48, uses a feature option for libbsd
```